### PR TITLE
Fix refresh token typo

### DIFF
--- a/src/vienna_smartmeter/_async/client.py
+++ b/src/vienna_smartmeter/_async/client.py
@@ -161,7 +161,7 @@ class AsyncSmartmeter:
                 )
                 logger.debug(f"REQUEST: {response}")
                 if response.status == 401:
-                    await self._refresh_token()
+                    await self.refresh_token()
                     return await self._request(endpoint, base_url, method, data, query)
                 return await response.json()
 


### PR DESCRIPTION
# Changes
Fix typo in async client module. When the api client is not authenticated and a request is made, it tries to refresh the token automatically and send the initial request again.