### PR TITLE
Add welcome endpoint

### DIFF
--- a/src/vienna_smartmeter/_async/client.py
+++ b/src/vienna_smartmeter/_async/client.py
@@ -133,6 +133,10 @@ class AsyncSmartmeter:
         """Returns zaehlpunkte for currently logged in user."""
         return await self._request("m/zaehlpunkte")
 
+    async def welcome(self):
+        """Returns response from 'welcome' endpoint."""
+        return await self._request("m/zaehlpunkt/default/welcome")
+
     async def _request(
         self,
         endpoint,

--- a/src/vienna_smartmeter/client.py
+++ b/src/vienna_smartmeter/client.py
@@ -118,6 +118,10 @@ class Smartmeter:
         """Returns zaehlpunkte for currently logged in user."""
         return self._call_api("m/zaehlpunkte")
 
+    def welcome(self):
+        """Returns response from 'welcome' endpoint."""
+        return self._call_api("m/zaehlpunkt/default/welcome")
+
     def verbrauch_raw(self, date_from, date_to=None, zaehlpunkt=None):
         """Returns energy usage.
 


### PR DESCRIPTION
The welcome endpoint returns various information, normally displayed on the welcome page in the smartmeter dashboard. As far as I know, it is the only API endpoint I could find that displays the most up to date total meter reading and could therefore come in handy.